### PR TITLE
chore(readme): add model helm chart in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Documentation on each individual chart can be found for
 
 - [Instill Base Helm Chart](https://github.com/instill-ai/base/blob/main/charts/base/README.md)
 - [Instill VDP Helm Chart](https://github.com/instill-ai/vdp/blob/main/charts/vdp/README.md)
+- [Instill Model Helm Chart](https://github.com/instill-ai/model/blob/main/charts/model/README.md)


### PR DESCRIPTION
Because

- to give model chart link in documentation.

This commit

- modified readme.md with model chart github link.
